### PR TITLE
Fix bugg #5 where additional execnames caused WYC to crash

### DIFF
--- a/WhoYouCalling/ETW/DNSClientListener.cs
+++ b/WhoYouCalling/ETW/DNSClientListener.cs
@@ -31,7 +31,7 @@ namespace WhoYouCalling.ETW
             {
                 case "EventID(3006)":
                     {
-                        if (IsAMonitoredProcess(data.ProcessID))
+                        if (Program.IsAMonitoredProcess(data.ProcessID))
                         {
                             string retrievedQuery = data.PayloadByName("QueryName").ToString().Trim();
                             string dnsDomainQueried = string.IsNullOrWhiteSpace(retrievedQuery) ? "N/A" : retrievedQuery;
@@ -61,7 +61,7 @@ namespace WhoYouCalling.ETW
                     }
                 case "EventID(3008)":
                     {
-                        if (IsAMonitoredProcess(data.ProcessID))
+                        if (Program.IsAMonitoredProcess(data.ProcessID))
                         {
                             string retrievedQuery = data.PayloadByName("QueryName").ToString().Trim();
                             string dnsQuery = string.IsNullOrWhiteSpace(retrievedQuery) ? "N/A" : retrievedQuery;

--- a/WhoYouCalling/ETW/Listener.cs
+++ b/WhoYouCalling/ETW/Listener.cs
@@ -4,28 +4,8 @@ namespace WhoYouCalling.ETW
 {
     internal class Listener
     {
-        protected int _trackedProcessId = 0;
-        protected string _mainExecutableFileName = "";
         protected TraceEventSession _session;
         public string SourceName = "";
-
-        public bool IsAMonitoredProcess(int pid)
-        {
-            if (_trackedProcessId == pid || Program.IsTrackedChildPID(pid))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-
-        public void SetPIDAndImageToTrack(int pid, string executable)
-        {
-            _mainExecutableFileName = executable;
-            _trackedProcessId = pid;
-        }
 
         public void StopSession()
         {

--- a/WhoYouCalling/Program.cs
+++ b/WhoYouCalling/Program.cs
@@ -180,8 +180,6 @@ namespace WhoYouCalling
                 CatalogETWActivity(eventType: EventType.Process, executable: s_mainExecutableFileName, execAction: "being listened to", execPID: s_trackedMainPid);
             }
 
-            s_etwDnsClientListener.SetPIDAndImageToTrack(s_trackedMainPid, s_mainExecutableFileName);
-            s_etwKernelListener.SetPIDAndImageToTrack(s_trackedMainPid, s_mainExecutableFileName);
             InstantiateProcessVariables(pid: s_trackedMainPid, executable: s_mainExecutableFileName, commandLine: s_mainExecutableCommandLine);
 
             if (s_argumentData.ProcessRunTimerWasProvided)
@@ -391,6 +389,18 @@ namespace WhoYouCalling
             var endTime = DateTime.Now;
             string monitorDuration = Generic.GetPresentableDuration(s_startTime, endTime);
             ConsoleOutput.Print($"Finished! Monitor duration: {monitorDuration}. Results are in the folder {s_rootFolderName}", PrintType.InfoTime);
+        }
+
+        public static bool IsAMonitoredProcess(int pid)
+        {
+            if (s_collectiveProcessInfo.ContainsKey(pid))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         private static bool ProcessHasNoRecordedNetworkActivity(MonitoredProcess monitoredProcess)


### PR DESCRIPTION
The `-x` flag caused WYC to crash due to improper instantiation of the processes as tracked processes. The issue was based on when processes were started, the section to manage executables that were based on their provided names expected that the parent pid was already monitored, similar to the previous approach with the child processes. The function has been reworked slightly to support different types of process starts. 

The issue highlights a need for more testing, but also the dependency of tracking the processes as the current state only records started processes (except for the one specified PID that can be provided as a starting argument). In the near future i would like to see WYC be able to record all network activity from all running processes on a machine, not just the ones being started. 